### PR TITLE
console_error_panic_hookのバージョンを0.1.5から0.1.7に更新する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,13 @@ lto = true
 # to interact with JavaScript.
 wasm-bindgen = "0.2.45"
 
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so it's only enabled
+# in debug mode.
+
+console_error_panic_hook = "0.1.7"
+
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. However, it is slower than the default
 # allocator, so it's not enabled by default.
@@ -35,13 +42,6 @@ wee_alloc = { version = "0.4.2", optional = true }
 [dependencies.web-sys]
 version = "0.3.22"
 features = ["console"]
-
-# The `console_error_panic_hook` crate provides better debugging of panics by
-# logging them with `console.error`. This is great for development, but requires
-# all the `std::fmt` and `std::panicking` infrastructure, so it's only enabled
-# in debug mode.
-[target."cfg(debug_assertions)".dependencies]
-console_error_panic_hook = "0.1.5"
 
 # These crates are used for running unit tests.
 [dev-dependencies]


### PR DESCRIPTION
## Issue
https://github.com/kossy0701/walk-the-dog/issues/3

## 概要
Issueに記載の通り、0.1.5だとバグがあるようで、[dependencies]配下に移して0.1.7に更新する。